### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/taihen/accel-exporter/security/code-scanning/1](https://github.com/taihen/accel-exporter/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only reads repository contents (e.g., for checking out code and running tests), the `contents: read` permission is sufficient. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
