### PR TITLE
build: upgrade to Go 1.26.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       # v8 action targets golangci-lint v2 (v6 installs v1, which rejects the v2
       # config). Default binary install mode fetches a prebuilt static binary,
       # so the linter version is decoupled from the repo's Go toolchain (latest
-      # golangci-lint needs Go >= 1.25; go.mod here targets 1.24).
+      # golangci-lint needs Go >= 1.25; go.mod here targets 1.26.4).
       - uses: golangci/golangci-lint-action@v8
         with:
           version: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM golang:1.21-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 # Set necessary environment variables
 ENV CGO_ENABLED=0 GOOS=linux

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Some small story behind this exporter on my [blog](https://taihen.org/posts/acce
 
 ## Minimum Requirements
 
-- Go 1.24 or higher (that what I'm using, most likely is compatible down to Go 1.20)
+- Go 1.26.4 or higher (that what I'm using, most likely is compatible down to Go 1.20)
 - Accel-PPP 1.12 or compatible version
 - Permission to execute `accel-cmd show stat` command
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/taihen/accel-exporter
 
-go 1.24
+go 1.26.4
 
 require github.com/prometheus/client_golang v1.23.2
 


### PR DESCRIPTION
## Summary
Upgrade project to Go 1.26.4 and make all version references consistent.

## Changes
- `go.mod` — `go 1.24` → `go 1.26.4`
- `Dockerfile` — builder image `golang:1.21-alpine` → `golang:1.26.4-alpine`
- `.github/workflows/test.yml` — fix stale comment to reflect `1.26.4`
- `README.md` — minimum requirement bumped to `Go 1.26.4`

CI picks up the new version via `go-version-file: go.mod`; `.goreleaser.yaml` / `release.yml` need no change.