### PR TITLE
refactor(collector): stateless const-metric design, bound scrapes, harden server

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ go install github.com/taihen/accel-exporter/cmd/accel-exporter@latest
 Usage of accel-exporter:
   -accel-cmd.path string
         Path to accel-cmd binary (default "accel-cmd")
+  -accel-cmd.timeout duration
+        Maximum time to wait for accel-cmd to return (default 5s)
   -log.level string
         Log level (debug, info, warn, error) (default "info")
   -web.listen-address string

--- a/cmd/accel-exporter/main.go
+++ b/cmd/accel-exporter/main.go
@@ -65,12 +65,19 @@ func main() {
 		</html>`, cfg.MetricsPath, versionInfo())
 	})
 
+	// Mirror the collector's clamp so a non-positive -accel-cmd.timeout cannot
+	// produce a too-short WriteTimeout that would truncate a legitimate scrape.
+	scrapeTimeout := cfg.ScrapeTimeout
+	if scrapeTimeout <= 0 {
+		scrapeTimeout = collector.DefaultScrapeTimeout
+	}
+
 	srv := &http.Server{
 		Addr:              cfg.ListenAddress,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 		ReadTimeout:       10 * time.Second,
-		WriteTimeout:      cfg.ScrapeTimeout + 10*time.Second,
+		WriteTimeout:      scrapeTimeout + 10*time.Second,
 		IdleTimeout:       2 * time.Minute,
 	}
 

--- a/cmd/accel-exporter/main.go
+++ b/cmd/accel-exporter/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -32,7 +33,7 @@ func main() {
 	log.Printf("Listening on %s, metrics path: %s", cfg.ListenAddress, cfg.MetricsPath)
 
 	// Create and register collector
-	accelCollector := collector.NewAccelCollector(cfg.AccelCmdPath)
+	accelCollector := collector.NewAccelCollector(cfg.AccelCmdPath, cfg.ScrapeTimeout)
 	prometheus.MustRegister(accelCollector)
 
 	// Add version information
@@ -46,9 +47,13 @@ func main() {
 	buildInfo.WithLabelValues(version, commit, date).Set(1)
 	prometheus.MustRegister(buildInfo)
 
-	// Set up HTTP server
-	http.Handle(cfg.MetricsPath, promhttp.Handler())
-	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+	// Set up HTTP server with an explicit mux and timeouts. ReadHeaderTimeout
+	// guards against Slowloris-style header dribbling; WriteTimeout is kept
+	// comfortably above the scrape timeout so a legitimately slow scrape is
+	// never truncated.
+	mux := http.NewServeMux()
+	mux.Handle(cfg.MetricsPath, promhttp.Handler())
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, _ = fmt.Fprintf(w, `<html>
 			<head><title>Accel-PPP Exporter</title></head>
@@ -60,5 +65,14 @@ func main() {
 		</html>`, cfg.MetricsPath, versionInfo())
 	})
 
-	log.Fatal(http.ListenAndServe(cfg.ListenAddress, nil))
+	srv := &http.Server{
+		Addr:              cfg.ListenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      cfg.ScrapeTimeout + 10*time.Second,
+		IdleTimeout:       2 * time.Minute,
+	}
+
+	log.Fatal(srv.ListenAndServe())
 }

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,16 @@ module github.com/taihen/accel-exporter
 
 go 1.26.4
 
-require github.com/prometheus/client_golang v1.23.2
+require (
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,604 +1,235 @@
 // Package collector implements the prometheus.Collector that scrapes accel-ppp
 // statistics and exposes them as Prometheus metrics.
+//
+// The collector is stateless: Collect parses a fresh snapshot and emits const
+// metrics built on the fly, so concurrent scrapes (e.g. an HA Prometheus pair)
+// never share mutable metric state. The only persistent metric is the
+// cumulative scrape-failure counter, whose increments are atomic.
 package collector
 
 import (
 	"log"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/taihen/accel-exporter/pkg/parser"
 )
 
+// radiusLabels are the labels attached to every per-RADIUS-server metric.
+var radiusLabels = []string{"server_id", "server_ip"}
+
+func newDesc(name, help string, labels ...string) *prometheus.Desc {
+	return prometheus.NewDesc(name, help, labels, nil)
+}
+
+// Descriptors are built once and shared across scrapes (they are immutable).
+var (
+	upDesc      = newDesc("accel_up", "Was the last accel-cmd scrape successful.")
+	uptimeDesc  = newDesc("accel_uptime_seconds", "Uptime of accel-ppp in seconds.")
+	cpuDesc     = newDesc("accel_cpu_usage_percent", "CPU usage percentage.")
+	memRSSDesc  = newDesc("accel_memory_rss_bytes", "RSS memory usage in bytes.")
+	memVirtDesc = newDesc("accel_memory_virtual_bytes", "Virtual memory usage in bytes.")
+
+	coreMempoolAllocatedDesc = newDesc("accel_core_mempool_allocated_bytes", "Allocated memory pool size.")
+	coreMempoolAvailableDesc = newDesc("accel_core_mempool_available_bytes", "Available memory pool size.")
+	coreThreadCountDesc      = newDesc("accel_core_thread_count", "Number of core threads.")
+	coreThreadActiveDesc     = newDesc("accel_core_thread_active", "Number of active core threads.")
+	coreContextCountDesc     = newDesc("accel_core_context_count", "Number of core contexts.")
+	coreContextSleepingDesc  = newDesc("accel_core_context_sleeping", "Number of sleeping core contexts.")
+	coreContextPendingDesc   = newDesc("accel_core_context_pending", "Number of pending core contexts.")
+	coreMDHandlerCountDesc   = newDesc("accel_core_md_handler_count", "Number of MD handlers.")
+	coreMDHandlerPendingDesc = newDesc("accel_core_md_handler_pending", "Number of pending MD handlers.")
+	coreTimerCountDesc       = newDesc("accel_core_timer_count", "Number of core timers.")
+	coreTimerPendingDesc     = newDesc("accel_core_timer_pending", "Number of pending core timers.")
+
+	sessionsStartingDesc  = newDesc("accel_sessions_starting", "Number of sessions starting.")
+	sessionsActiveDesc    = newDesc("accel_sessions_active", "Number of active sessions.")
+	sessionsFinishingDesc = newDesc("accel_sessions_finishing", "Number of sessions finishing.")
+
+	pppoeStartingDesc    = newDesc("accel_pppoe_starting", "Number of PPPoE sessions starting.")
+	pppoeActiveDesc      = newDesc("accel_pppoe_active", "Number of active PPPoE sessions.")
+	pppoeDelayedPADODesc = newDesc("accel_pppoe_delayed_pado", "Number of delayed PADO packets.")
+	pppoeRecvPADIDesc    = newDesc("accel_pppoe_recv_padi_total", "Total received PADI packets.")
+	pppoeDropPADIDesc    = newDesc("accel_pppoe_drop_padi_total", "Total dropped PADI packets.")
+	pppoeSentPADODesc    = newDesc("accel_pppoe_sent_pado_total", "Total sent PADO packets.")
+	pppoeRecvPADRDesc    = newDesc("accel_pppoe_recv_padr_total", "Total received PADR packets.")
+	pppoeRecvPADRDupDesc = newDesc("accel_pppoe_recv_padr_dup_total", "Total received duplicate PADR packets.")
+	pppoeSentPADSDesc    = newDesc("accel_pppoe_sent_pads_total", "Total sent PADS packets.")
+	pppoeFilteredDesc    = newDesc("accel_pppoe_filtered_total", "Total filtered PPPoE packets.")
+
+	radiusStateDesc            = newDesc("accel_radius_state", "State of RADIUS server (1 = active, 0 = inactive).", radiusLabels...)
+	radiusFailCountDesc        = newDesc("accel_radius_fail_count_total", "Total RADIUS server fail count.", radiusLabels...)
+	radiusRequestCountDesc     = newDesc("accel_radius_request_count", "Current RADIUS server request count.", radiusLabels...)
+	radiusQueueLengthDesc      = newDesc("accel_radius_queue_length", "Current RADIUS server queue length.", radiusLabels...)
+	radiusAuthSentDesc         = newDesc("accel_radius_auth_sent_total", "Total RADIUS auth packets sent.", radiusLabels...)
+	radiusAuthLostTotalDesc    = newDesc("accel_radius_auth_lost_total", "Total RADIUS auth packets lost.", radiusLabels...)
+	radiusAuthLost5mDesc       = newDesc("accel_radius_auth_lost_5m", "RADIUS auth packets lost in the last 5 minutes.", radiusLabels...)
+	radiusAuthLost1mDesc       = newDesc("accel_radius_auth_lost_1m", "RADIUS auth packets lost in the last 1 minute.", radiusLabels...)
+	radiusAuthAvgTime5mDesc    = newDesc("accel_radius_auth_avg_time_5m_seconds", "Average RADIUS auth response time in the last 5 minutes (seconds).", radiusLabels...)
+	radiusAuthAvgTime1mDesc    = newDesc("accel_radius_auth_avg_time_1m_seconds", "Average RADIUS auth response time in the last 1 minute (seconds).", radiusLabels...)
+	radiusAcctSentDesc         = newDesc("accel_radius_acct_sent_total", "Total RADIUS accounting packets sent.", radiusLabels...)
+	radiusAcctLostTotalDesc    = newDesc("accel_radius_acct_lost_total", "Total RADIUS accounting packets lost.", radiusLabels...)
+	radiusAcctLost5mDesc       = newDesc("accel_radius_acct_lost_5m", "RADIUS accounting packets lost in the last 5 minutes.", radiusLabels...)
+	radiusAcctLost1mDesc       = newDesc("accel_radius_acct_lost_1m", "RADIUS accounting packets lost in the last 1 minute.", radiusLabels...)
+	radiusAcctAvgTime5mDesc    = newDesc("accel_radius_acct_avg_time_5m_seconds", "Average RADIUS accounting response time in the last 5 minutes (seconds).", radiusLabels...)
+	radiusAcctAvgTime1mDesc    = newDesc("accel_radius_acct_avg_time_1m_seconds", "Average RADIUS accounting response time in the last 1 minute (seconds).", radiusLabels...)
+	radiusInterimSentDesc      = newDesc("accel_radius_interim_sent_total", "Total RADIUS interim accounting packets sent.", radiusLabels...)
+	radiusInterimLostTotalDesc = newDesc("accel_radius_interim_lost_total", "Total RADIUS interim accounting packets lost.", radiusLabels...)
+	radiusInterimLost5mDesc    = newDesc("accel_radius_interim_lost_5m", "RADIUS interim accounting packets lost in the last 5 minutes.", radiusLabels...)
+	radiusInterimLost1mDesc    = newDesc("accel_radius_interim_lost_1m", "RADIUS interim accounting packets lost in the last 1 minute.", radiusLabels...)
+	radiusInterimAvgTime5mDesc = newDesc("accel_radius_interim_avg_time_5m_seconds", "Average RADIUS interim accounting response time in the last 5 minutes (seconds).", radiusLabels...)
+	radiusInterimAvgTime1mDesc = newDesc("accel_radius_interim_avg_time_1m_seconds", "Average RADIUS interim accounting response time in the last 1 minute (seconds).", radiusLabels...)
+)
+
+// allDescs lists every descriptor the collector can emit, for Describe.
+var allDescs = []*prometheus.Desc{
+	upDesc, uptimeDesc, cpuDesc, memRSSDesc, memVirtDesc,
+	coreMempoolAllocatedDesc, coreMempoolAvailableDesc, coreThreadCountDesc, coreThreadActiveDesc,
+	coreContextCountDesc, coreContextSleepingDesc, coreContextPendingDesc,
+	coreMDHandlerCountDesc, coreMDHandlerPendingDesc, coreTimerCountDesc, coreTimerPendingDesc,
+	sessionsStartingDesc, sessionsActiveDesc, sessionsFinishingDesc,
+	pppoeStartingDesc, pppoeActiveDesc, pppoeDelayedPADODesc, pppoeRecvPADIDesc, pppoeDropPADIDesc,
+	pppoeSentPADODesc, pppoeRecvPADRDesc, pppoeRecvPADRDupDesc, pppoeSentPADSDesc, pppoeFilteredDesc,
+	radiusStateDesc, radiusFailCountDesc, radiusRequestCountDesc, radiusQueueLengthDesc,
+	radiusAuthSentDesc, radiusAuthLostTotalDesc, radiusAuthLost5mDesc, radiusAuthLost1mDesc,
+	radiusAuthAvgTime5mDesc, radiusAuthAvgTime1mDesc,
+	radiusAcctSentDesc, radiusAcctLostTotalDesc, radiusAcctLost5mDesc, radiusAcctLost1mDesc,
+	radiusAcctAvgTime5mDesc, radiusAcctAvgTime1mDesc,
+	radiusInterimSentDesc, radiusInterimLostTotalDesc, radiusInterimLost5mDesc, radiusInterimLost1mDesc,
+	radiusInterimAvgTime5mDesc, radiusInterimAvgTime1mDesc,
+}
+
+// DefaultScrapeTimeout bounds an accel-cmd invocation when none is configured.
+const DefaultScrapeTimeout = 5 * time.Second
+
 // AccelCollector implements the prometheus.Collector interface
 type AccelCollector struct {
 	accelCmdPath string
+	timeout      time.Duration
 
-	// General metrics
-	up             prometheus.Gauge
+	// scrapeFailures is the only persistent metric: a cumulative counter whose
+	// Inc is atomic and safe under concurrent scrapes.
 	scrapeFailures prometheus.Counter
-	uptimeSeconds  prometheus.Gauge
-	cpuPercent     prometheus.Gauge
-	memRSS         prometheus.Gauge
-	memVirt        prometheus.Gauge
-
-	// Core metrics
-	coreMempoolAllocated prometheus.Gauge
-	coreMempoolAvailable prometheus.Gauge
-	coreThreadCount      prometheus.Gauge
-	coreThreadActive     prometheus.Gauge
-	coreContextCount     prometheus.Gauge
-	coreContextSleeping  prometheus.Gauge
-	coreContextPending   prometheus.Gauge
-	coreMDHandlerCount   prometheus.Gauge
-	coreMDHandlerPending prometheus.Gauge
-	coreTimerCount       prometheus.Gauge
-	coreTimerPending     prometheus.Gauge
-
-	// Session metrics
-	sessionsStarting  prometheus.Gauge
-	sessionsActive    prometheus.Gauge
-	sessionsFinishing prometheus.Gauge
-
-	// PPPoE metrics
-	pppoeStarting    prometheus.Gauge
-	pppoeActive      prometheus.Gauge
-	pppoeDelayedPADO prometheus.Gauge
-	pppoeRecvPADI    prometheus.Gauge
-	pppoeDropPADI    prometheus.Gauge
-	pppoeSentPADO    prometheus.Gauge
-	pppoeRecvPADR    prometheus.Gauge
-	pppoeRecvPADRDup prometheus.Gauge
-	pppoeSentPADS    prometheus.Gauge
-	pppoeFiltered    prometheus.Gauge
-
-	// RADIUS metrics
-	radiusState            *prometheus.GaugeVec
-	radiusFailCount        *prometheus.GaugeVec
-	radiusRequestCount     *prometheus.GaugeVec
-	radiusQueueLength      *prometheus.GaugeVec
-	radiusAuthSent         *prometheus.GaugeVec
-	radiusAuthLostTotal    *prometheus.GaugeVec
-	radiusAuthLost5m       *prometheus.GaugeVec
-	radiusAuthLost1m       *prometheus.GaugeVec
-	radiusAuthAvgTime5m    *prometheus.GaugeVec
-	radiusAuthAvgTime1m    *prometheus.GaugeVec
-	radiusAcctSent         *prometheus.GaugeVec
-	radiusAcctLostTotal    *prometheus.GaugeVec
-	radiusAcctLost5m       *prometheus.GaugeVec
-	radiusAcctLost1m       *prometheus.GaugeVec
-	radiusAcctAvgTime5m    *prometheus.GaugeVec
-	radiusAcctAvgTime1m    *prometheus.GaugeVec
-	radiusInterimSent      *prometheus.GaugeVec
-	radiusInterimLostTotal *prometheus.GaugeVec
-	radiusInterimLost5m    *prometheus.GaugeVec
-	radiusInterimLost1m    *prometheus.GaugeVec
-	radiusInterimAvgTime5m *prometheus.GaugeVec
-	radiusInterimAvgTime1m *prometheus.GaugeVec
 }
 
-// NewAccelCollector creates a new AccelCollector
-func NewAccelCollector(accelCmdPath string) *AccelCollector {
-	radiusLabels := []string{"server_id", "server_ip"}
-
+// NewAccelCollector creates a new AccelCollector. A non-positive timeout falls
+// back to DefaultScrapeTimeout.
+func NewAccelCollector(accelCmdPath string, timeout time.Duration) *AccelCollector {
+	if timeout <= 0 {
+		timeout = DefaultScrapeTimeout
+	}
 	return &AccelCollector{
 		accelCmdPath: accelCmdPath,
-
-		up: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_up",
-			Help: "Was the last accel-cmd scrape successful.",
-		}),
+		timeout:      timeout,
 		scrapeFailures: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "accel_scrape_failures_total",
 			Help: "Number of errors while scraping accel-cmd.",
 		}),
-		uptimeSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_uptime_seconds",
-			Help: "Uptime of accel-ppp in seconds.",
-		}),
-		cpuPercent: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_cpu_usage_percent",
-			Help: "CPU usage percentage.",
-		}),
-		memRSS: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_memory_rss_bytes",
-			Help: "RSS memory usage in bytes.",
-		}),
-		memVirt: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_memory_virtual_bytes",
-			Help: "Virtual memory usage in bytes.",
-		}),
-
-		// Core metrics initialization
-		coreMempoolAllocated: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_mempool_allocated_bytes",
-			Help: "Allocated memory pool size.",
-		}),
-		coreMempoolAvailable: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_mempool_available_bytes",
-			Help: "Available memory pool size.",
-		}),
-		coreThreadCount: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_thread_count",
-			Help: "Number of core threads.",
-		}),
-		coreThreadActive: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_thread_active",
-			Help: "Number of active core threads.",
-		}),
-		coreContextCount: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_context_count",
-			Help: "Number of core contexts.",
-		}),
-		coreContextSleeping: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_context_sleeping",
-			Help: "Number of sleeping core contexts.",
-		}),
-		coreContextPending: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_context_pending",
-			Help: "Number of pending core contexts.",
-		}),
-		coreMDHandlerCount: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_md_handler_count",
-			Help: "Number of MD handlers.",
-		}),
-		coreMDHandlerPending: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_md_handler_pending",
-			Help: "Number of pending MD handlers.",
-		}),
-		coreTimerCount: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_timer_count",
-			Help: "Number of core timers.",
-		}),
-		coreTimerPending: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_core_timer_pending",
-			Help: "Number of pending core timers.",
-		}),
-
-		// Session metrics
-		sessionsStarting: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_sessions_starting",
-			Help: "Number of sessions starting.",
-		}),
-		sessionsActive: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_sessions_active",
-			Help: "Number of active sessions.",
-		}),
-		sessionsFinishing: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_sessions_finishing",
-			Help: "Number of sessions finishing.",
-		}),
-
-		// PPPoE metrics
-		pppoeStarting: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_starting",
-			Help: "Number of PPPoE sessions starting.",
-		}),
-		pppoeActive: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_active",
-			Help: "Number of active PPPoE sessions.",
-		}),
-		pppoeDelayedPADO: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_delayed_pado",
-			Help: "Number of delayed PADO packets.",
-		}),
-		pppoeRecvPADI: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_recv_padi_total",
-			Help: "Total received PADI packets.",
-		}),
-		pppoeDropPADI: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_drop_padi_total",
-			Help: "Total dropped PADI packets.",
-		}),
-		pppoeSentPADO: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_sent_pado_total",
-			Help: "Total sent PADO packets.",
-		}),
-		pppoeRecvPADR: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_recv_padr_total",
-			Help: "Total received PADR packets.",
-		}),
-		pppoeRecvPADRDup: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_recv_padr_dup_total",
-			Help: "Total received duplicate PADR packets.",
-		}),
-		pppoeSentPADS: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_sent_pads_total",
-			Help: "Total sent PADS packets.",
-		}),
-		pppoeFiltered: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: "accel_pppoe_filtered_total",
-			Help: "Total filtered PPPoE packets.",
-		}),
-
-		// RADIUS metrics with labels
-		radiusState: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_state",
-				Help: "State of RADIUS server (1 = active, 0 = inactive).",
-			},
-			radiusLabels,
-		),
-		radiusFailCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_fail_count_total",
-				Help: "Total RADIUS server fail count.",
-			},
-			radiusLabels,
-		),
-		radiusRequestCount: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_request_count",
-				Help: "Current RADIUS server request count.",
-			},
-			radiusLabels,
-		),
-		radiusQueueLength: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_queue_length",
-				Help: "Current RADIUS server queue length.",
-			},
-			radiusLabels,
-		),
-		radiusAuthSent: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_auth_sent_total",
-				Help: "Total RADIUS auth packets sent.",
-			},
-			radiusLabels,
-		),
-		radiusAuthLostTotal: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_auth_lost_total",
-				Help: "Total RADIUS auth packets lost.",
-			},
-			radiusLabels,
-		),
-		radiusAuthLost5m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_auth_lost_5m",
-				Help: "RADIUS auth packets lost in the last 5 minutes.",
-			},
-			radiusLabels,
-		),
-		radiusAuthLost1m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_auth_lost_1m",
-				Help: "RADIUS auth packets lost in the last 1 minute.",
-			},
-			radiusLabels,
-		),
-		radiusAuthAvgTime5m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_auth_avg_time_5m_seconds",
-				Help: "Average RADIUS auth response time in the last 5 minutes (seconds).",
-			},
-			radiusLabels,
-		),
-		radiusAuthAvgTime1m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_auth_avg_time_1m_seconds",
-				Help: "Average RADIUS auth response time in the last 1 minute (seconds).",
-			},
-			radiusLabels,
-		),
-		radiusAcctSent: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_acct_sent_total",
-				Help: "Total RADIUS accounting packets sent.",
-			},
-			radiusLabels,
-		),
-		radiusAcctLostTotal: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_acct_lost_total",
-				Help: "Total RADIUS accounting packets lost.",
-			},
-			radiusLabels,
-		),
-		radiusAcctLost5m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_acct_lost_5m",
-				Help: "RADIUS accounting packets lost in the last 5 minutes.",
-			},
-			radiusLabels,
-		),
-		radiusAcctLost1m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_acct_lost_1m",
-				Help: "RADIUS accounting packets lost in the last 1 minute.",
-			},
-			radiusLabels,
-		),
-		radiusAcctAvgTime5m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_acct_avg_time_5m_seconds",
-				Help: "Average RADIUS accounting response time in the last 5 minutes (seconds).",
-			},
-			radiusLabels,
-		),
-		radiusAcctAvgTime1m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_acct_avg_time_1m_seconds",
-				Help: "Average RADIUS accounting response time in the last 1 minute (seconds).",
-			},
-			radiusLabels,
-		),
-		radiusInterimSent: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_interim_sent_total",
-				Help: "Total RADIUS interim accounting packets sent.",
-			},
-			radiusLabels,
-		),
-		radiusInterimLostTotal: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_interim_lost_total",
-				Help: "Total RADIUS interim accounting packets lost.",
-			},
-			radiusLabels,
-		),
-		radiusInterimLost5m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_interim_lost_5m",
-				Help: "RADIUS interim accounting packets lost in the last 5 minutes.",
-			},
-			radiusLabels,
-		),
-		radiusInterimLost1m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_interim_lost_1m",
-				Help: "RADIUS interim accounting packets lost in the last 1 minute.",
-			},
-			radiusLabels,
-		),
-		radiusInterimAvgTime5m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_interim_avg_time_5m_seconds",
-				Help: "Average RADIUS interim accounting response time in the last 5 minutes (seconds).",
-			},
-			radiusLabels,
-		),
-		radiusInterimAvgTime1m: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "accel_radius_interim_avg_time_1m_seconds",
-				Help: "Average RADIUS interim accounting response time in the last 1 minute (seconds).",
-			},
-			radiusLabels,
-		),
 	}
 }
 
 // Describe implements the prometheus.Collector interface
 func (c *AccelCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.up.Desc()
-	ch <- c.scrapeFailures.Desc()
-	ch <- c.uptimeSeconds.Desc()
-	ch <- c.cpuPercent.Desc()
-	ch <- c.memRSS.Desc()
-	ch <- c.memVirt.Desc()
-
-	// Core metrics
-	ch <- c.coreMempoolAllocated.Desc()
-	ch <- c.coreMempoolAvailable.Desc()
-	ch <- c.coreThreadCount.Desc()
-	ch <- c.coreThreadActive.Desc()
-	ch <- c.coreContextCount.Desc()
-	ch <- c.coreContextSleeping.Desc()
-	ch <- c.coreContextPending.Desc()
-	ch <- c.coreMDHandlerCount.Desc()
-	ch <- c.coreMDHandlerPending.Desc()
-	ch <- c.coreTimerCount.Desc()
-	ch <- c.coreTimerPending.Desc()
-
-	// Session metrics
-	ch <- c.sessionsStarting.Desc()
-	ch <- c.sessionsActive.Desc()
-	ch <- c.sessionsFinishing.Desc()
-
-	// PPPoE metrics
-	ch <- c.pppoeStarting.Desc()
-	ch <- c.pppoeActive.Desc()
-	ch <- c.pppoeDelayedPADO.Desc()
-	ch <- c.pppoeRecvPADI.Desc()
-	ch <- c.pppoeDropPADI.Desc()
-	ch <- c.pppoeSentPADO.Desc()
-	ch <- c.pppoeRecvPADR.Desc()
-	ch <- c.pppoeRecvPADRDup.Desc()
-	ch <- c.pppoeSentPADS.Desc()
-	ch <- c.pppoeFiltered.Desc()
-
-	// RADIUS metrics
-	c.radiusState.Describe(ch)
-	c.radiusFailCount.Describe(ch)
-	c.radiusRequestCount.Describe(ch)
-	c.radiusQueueLength.Describe(ch)
-	c.radiusAuthSent.Describe(ch)
-	c.radiusAuthLostTotal.Describe(ch)
-	c.radiusAuthLost5m.Describe(ch)
-	c.radiusAuthLost1m.Describe(ch)
-	c.radiusAuthAvgTime5m.Describe(ch)
-	c.radiusAuthAvgTime1m.Describe(ch)
-	c.radiusAcctSent.Describe(ch)
-	c.radiusAcctLostTotal.Describe(ch)
-	c.radiusAcctLost5m.Describe(ch)
-	c.radiusAcctLost1m.Describe(ch)
-	c.radiusAcctAvgTime5m.Describe(ch)
-	c.radiusAcctAvgTime1m.Describe(ch)
-	c.radiusInterimSent.Describe(ch)
-	c.radiusInterimLostTotal.Describe(ch)
-	c.radiusInterimLost5m.Describe(ch)
-	c.radiusInterimLost1m.Describe(ch)
-	c.radiusInterimAvgTime5m.Describe(ch)
-	c.radiusInterimAvgTime1m.Describe(ch)
+	for _, d := range allDescs {
+		ch <- d
+	}
+	c.scrapeFailures.Describe(ch)
 }
 
-// Collect implements the prometheus.Collector interface
+// Collect implements the prometheus.Collector interface. It builds const
+// metrics from a fresh snapshot, so it holds no mutable state between or during
+// scrapes and is safe to run concurrently.
 func (c *AccelCollector) Collect(ch chan<- prometheus.Metric) {
-	stats, err := parser.CollectStats(c.accelCmdPath)
+	stats, err := parser.CollectStats(c.accelCmdPath, c.timeout)
 	if err != nil {
-		c.up.Set(0)
 		c.scrapeFailures.Inc()
-		ch <- c.up
 		ch <- c.scrapeFailures
+		ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, 0)
 		log.Printf("Error collecting stats: %v", err)
 		return
 	}
 
-	c.up.Set(1)
-	ch <- c.up
+	ch <- c.scrapeFailures
+	ch <- prometheus.MustNewConstMetric(upDesc, prometheus.GaugeValue, 1)
 
-	// Set general metrics
-	c.uptimeSeconds.Set(stats.Uptime)
-	ch <- c.uptimeSeconds
+	gauge := func(d *prometheus.Desc, v float64) {
+		ch <- prometheus.MustNewConstMetric(d, prometheus.GaugeValue, v)
+	}
+	counter := func(d *prometheus.Desc, v float64) {
+		ch <- prometheus.MustNewConstMetric(d, prometheus.CounterValue, v)
+	}
 
-	c.cpuPercent.Set(stats.CPUPercent)
-	ch <- c.cpuPercent
+	// General
+	gauge(uptimeDesc, stats.Uptime)
+	gauge(cpuDesc, stats.CPUPercent)
+	gauge(memRSSDesc, stats.MemRSS*1024)   // KB -> bytes
+	gauge(memVirtDesc, stats.MemVirt*1024) // KB -> bytes
 
-	c.memRSS.Set(stats.MemRSS * 1024) // Convert KB to bytes
-	ch <- c.memRSS
+	// Core
+	gauge(coreMempoolAllocatedDesc, stats.Core.MempoolAllocated)
+	gauge(coreMempoolAvailableDesc, stats.Core.MempoolAvailable)
+	gauge(coreThreadCountDesc, stats.Core.ThreadCount)
+	gauge(coreThreadActiveDesc, stats.Core.ThreadActive)
+	gauge(coreContextCountDesc, stats.Core.ContextCount)
+	gauge(coreContextSleepingDesc, stats.Core.ContextSleeping)
+	gauge(coreContextPendingDesc, stats.Core.ContextPending)
+	gauge(coreMDHandlerCountDesc, stats.Core.MDHandlerCount)
+	gauge(coreMDHandlerPendingDesc, stats.Core.MDHandlerPending)
+	gauge(coreTimerCountDesc, stats.Core.TimerCount)
+	gauge(coreTimerPendingDesc, stats.Core.TimerPending)
 
-	c.memVirt.Set(stats.MemVirt * 1024) // Convert KB to bytes
-	ch <- c.memVirt
+	// Sessions
+	gauge(sessionsStartingDesc, stats.Sessions.Starting)
+	gauge(sessionsActiveDesc, stats.Sessions.Active)
+	gauge(sessionsFinishingDesc, stats.Sessions.Finishing)
 
-	// Set core metrics
-	c.coreMempoolAllocated.Set(stats.Core.MempoolAllocated)
-	ch <- c.coreMempoolAllocated
-	c.coreMempoolAvailable.Set(stats.Core.MempoolAvailable)
-	ch <- c.coreMempoolAvailable
-	c.coreThreadCount.Set(stats.Core.ThreadCount)
-	ch <- c.coreThreadCount
-	c.coreThreadActive.Set(stats.Core.ThreadActive)
-	ch <- c.coreThreadActive
-	c.coreContextCount.Set(stats.Core.ContextCount)
-	ch <- c.coreContextCount
-	c.coreContextSleeping.Set(stats.Core.ContextSleeping)
-	ch <- c.coreContextSleeping
-	c.coreContextPending.Set(stats.Core.ContextPending)
-	ch <- c.coreContextPending
-	c.coreMDHandlerCount.Set(stats.Core.MDHandlerCount)
-	ch <- c.coreMDHandlerCount
-	c.coreMDHandlerPending.Set(stats.Core.MDHandlerPending)
-	ch <- c.coreMDHandlerPending
-	c.coreTimerCount.Set(stats.Core.TimerCount)
-	ch <- c.coreTimerCount
-	c.coreTimerPending.Set(stats.Core.TimerPending)
-	ch <- c.coreTimerPending
+	// PPPoE
+	gauge(pppoeStartingDesc, stats.PPPoE.Starting)
+	gauge(pppoeActiveDesc, stats.PPPoE.Active)
+	gauge(pppoeDelayedPADODesc, stats.PPPoE.DelayedPADO)
+	counter(pppoeRecvPADIDesc, stats.PPPoE.RecvPADI)
+	counter(pppoeDropPADIDesc, stats.PPPoE.DropPADI)
+	counter(pppoeSentPADODesc, stats.PPPoE.SentPADO)
+	counter(pppoeRecvPADRDesc, stats.PPPoE.RecvPADR)
+	counter(pppoeRecvPADRDupDesc, stats.PPPoE.RecvPADRDup)
+	counter(pppoeSentPADSDesc, stats.PPPoE.SentPADS)
+	counter(pppoeFilteredDesc, stats.PPPoE.Filtered)
 
-	// Set session metrics
-	c.sessionsStarting.Set(stats.Sessions.Starting)
-	ch <- c.sessionsStarting
-	c.sessionsActive.Set(stats.Sessions.Active)
-	ch <- c.sessionsActive
-	c.sessionsFinishing.Set(stats.Sessions.Finishing)
-	ch <- c.sessionsFinishing
-
-	// Set PPPoE metrics
-	c.pppoeStarting.Set(stats.PPPoE.Starting)
-	ch <- c.pppoeStarting
-	c.pppoeActive.Set(stats.PPPoE.Active)
-	ch <- c.pppoeActive
-	c.pppoeDelayedPADO.Set(stats.PPPoE.DelayedPADO)
-	ch <- c.pppoeDelayedPADO
-	// Note: The original code used .Add() for counters here, but Collect should set the current value.
-	// If these are truly counters, they should be handled differently, perhaps by storing the previous value.
-	// For simplicity based on the provided structure, we'll use Set here, assuming the parser provides the total count.
-	// If the parser provides increments, .Add() would be correct, but Prometheus counters should generally only increase.
-	// A better approach might be to fetch the previous value or rely on Prometheus's rate() function.
-	// Sticking to the provided structure for now, using Set for counters as well.
-	c.pppoeRecvPADI.Set(stats.PPPoE.RecvPADI)
-	ch <- c.pppoeRecvPADI
-	c.pppoeDropPADI.Set(stats.PPPoE.DropPADI)
-	ch <- c.pppoeDropPADI
-	c.pppoeSentPADO.Set(stats.PPPoE.SentPADO)
-	ch <- c.pppoeSentPADO
-	c.pppoeRecvPADR.Set(stats.PPPoE.RecvPADR)
-	ch <- c.pppoeRecvPADR
-	c.pppoeRecvPADRDup.Set(stats.PPPoE.RecvPADRDup)
-	ch <- c.pppoeRecvPADRDup
-	c.pppoeSentPADS.Set(stats.PPPoE.SentPADS)
-	ch <- c.pppoeSentPADS
-	c.pppoeFiltered.Set(stats.PPPoE.Filtered)
-	ch <- c.pppoeFiltered
-
-	// Set RADIUS metrics
-	// Reset vectors before setting new values to avoid stale metrics if a server disappears
-	c.radiusState.Reset()
-	c.radiusFailCount.Reset()
-	c.radiusRequestCount.Reset()
-	c.radiusQueueLength.Reset()
-	c.radiusAuthSent.Reset()
-	c.radiusAuthLostTotal.Reset()
-	c.radiusAuthLost5m.Reset()
-	c.radiusAuthLost1m.Reset()
-	c.radiusAuthAvgTime5m.Reset()
-	c.radiusAuthAvgTime1m.Reset()
-	c.radiusAcctSent.Reset()
-	c.radiusAcctLostTotal.Reset()
-	c.radiusAcctLost5m.Reset()
-	c.radiusAcctLost1m.Reset()
-	c.radiusAcctAvgTime5m.Reset()
-	c.radiusAcctAvgTime1m.Reset()
-	c.radiusInterimSent.Reset()
-	c.radiusInterimLostTotal.Reset()
-	c.radiusInterimLost5m.Reset()
-	c.radiusInterimLost1m.Reset()
-	c.radiusInterimAvgTime5m.Reset()
-	c.radiusInterimAvgTime1m.Reset()
-
+	// RADIUS (per server). Absent servers are simply not emitted, so stale
+	// series disappear automatically without any reset bookkeeping.
 	for id, rs := range stats.RadiusServers {
 		state := 0.0
 		if rs.State == "active" {
 			state = 1.0
 		}
+		rGauge := func(d *prometheus.Desc, v float64) {
+			ch <- prometheus.MustNewConstMetric(d, prometheus.GaugeValue, v, id, rs.IP)
+		}
+		rCounter := func(d *prometheus.Desc, v float64) {
+			ch <- prometheus.MustNewConstMetric(d, prometheus.CounterValue, v, id, rs.IP)
+		}
 
-		labels := prometheus.Labels{"server_id": id, "server_ip": rs.IP}
-
-		c.radiusState.With(labels).Set(state)
-		// Assuming FailCount from parser is the total count, set the counter value directly.
-		c.radiusFailCount.With(labels).Set(rs.FailCount)
-		c.radiusRequestCount.With(labels).Set(rs.RequestCount)
-		c.radiusQueueLength.With(labels).Set(rs.QueueLength)
-		c.radiusAuthSent.With(labels).Set(rs.AuthSent)
-		c.radiusAuthLostTotal.With(labels).Set(rs.AuthLostTotal)
-		c.radiusAuthLost5m.With(labels).Set(rs.AuthLost5m)
-		c.radiusAuthLost1m.With(labels).Set(rs.AuthLost1m)
-		c.radiusAuthAvgTime5m.With(labels).Set(rs.AuthAvgTime5m)
-		c.radiusAuthAvgTime1m.With(labels).Set(rs.AuthAvgTime1m)
-		c.radiusAcctSent.With(labels).Set(rs.AcctSent)
-		c.radiusAcctLostTotal.With(labels).Set(rs.AcctLostTotal)
-		c.radiusAcctLost5m.With(labels).Set(rs.AcctLost5m)
-		c.radiusAcctLost1m.With(labels).Set(rs.AcctLost1m)
-		c.radiusAcctAvgTime5m.With(labels).Set(rs.AcctAvgTime5m)
-		c.radiusAcctAvgTime1m.With(labels).Set(rs.AcctAvgTime1m)
-		c.radiusInterimSent.With(labels).Set(rs.InterimSent)
-		c.radiusInterimLostTotal.With(labels).Set(rs.InterimLostTotal)
-		c.radiusInterimLost5m.With(labels).Set(rs.InterimLost5m)
-		c.radiusInterimLost1m.With(labels).Set(rs.InterimLost1m)
-		c.radiusInterimAvgTime5m.With(labels).Set(rs.InterimAvgTime5m)
-		c.radiusInterimAvgTime1m.With(labels).Set(rs.InterimAvgTime1m)
+		rGauge(radiusStateDesc, state)
+		rCounter(radiusFailCountDesc, rs.FailCount)
+		rGauge(radiusRequestCountDesc, rs.RequestCount)
+		rGauge(radiusQueueLengthDesc, rs.QueueLength)
+		rCounter(radiusAuthSentDesc, rs.AuthSent)
+		rCounter(radiusAuthLostTotalDesc, rs.AuthLostTotal)
+		rGauge(radiusAuthLost5mDesc, rs.AuthLost5m)
+		rGauge(radiusAuthLost1mDesc, rs.AuthLost1m)
+		rGauge(radiusAuthAvgTime5mDesc, rs.AuthAvgTime5m)
+		rGauge(radiusAuthAvgTime1mDesc, rs.AuthAvgTime1m)
+		rCounter(radiusAcctSentDesc, rs.AcctSent)
+		rCounter(radiusAcctLostTotalDesc, rs.AcctLostTotal)
+		rGauge(radiusAcctLost5mDesc, rs.AcctLost5m)
+		rGauge(radiusAcctLost1mDesc, rs.AcctLost1m)
+		rGauge(radiusAcctAvgTime5mDesc, rs.AcctAvgTime5m)
+		rGauge(radiusAcctAvgTime1mDesc, rs.AcctAvgTime1m)
+		rCounter(radiusInterimSentDesc, rs.InterimSent)
+		rCounter(radiusInterimLostTotalDesc, rs.InterimLostTotal)
+		rGauge(radiusInterimLost5mDesc, rs.InterimLost5m)
+		rGauge(radiusInterimLost1mDesc, rs.InterimLost1m)
+		rGauge(radiusInterimAvgTime5mDesc, rs.InterimAvgTime5m)
+		rGauge(radiusInterimAvgTime1mDesc, rs.InterimAvgTime1m)
 	}
-
-	// Collect all vector metrics
-	c.radiusState.Collect(ch)
-	c.radiusFailCount.Collect(ch)
-	c.radiusRequestCount.Collect(ch)
-	c.radiusQueueLength.Collect(ch)
-	c.radiusAuthSent.Collect(ch)
-	c.radiusAuthLostTotal.Collect(ch)
-	c.radiusAuthLost5m.Collect(ch)
-	c.radiusAuthLost1m.Collect(ch)
-	c.radiusAuthAvgTime5m.Collect(ch)
-	c.radiusAuthAvgTime1m.Collect(ch)
-	c.radiusAcctSent.Collect(ch)
-	c.radiusAcctLostTotal.Collect(ch)
-	c.radiusAcctLost5m.Collect(ch)
-	c.radiusAcctLost1m.Collect(ch)
-	c.radiusAcctAvgTime5m.Collect(ch)
-	c.radiusAcctAvgTime1m.Collect(ch)
-	c.radiusInterimSent.Collect(ch)
-	c.radiusInterimLostTotal.Collect(ch)
-	c.radiusInterimLost5m.Collect(ch)
-	c.radiusInterimLost1m.Collect(ch)
-	c.radiusInterimAvgTime5m.Collect(ch)
-	c.radiusInterimAvgTime1m.Collect(ch)
 }

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -1,21 +1,59 @@
 package collector
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
+const sampleStat = `uptime: 138.00:05:20
+cpu: 1.50%
+mem(rss/virt): 12345 / 67890 K
+pppoe:
+  active: 90
+  recv PADI: 1000
+radius(1, 10.0.0.1):
+  state: active
+  auth sent: 500
+`
+
+// fakeCollector returns a collector backed by an executable shell script that
+// prints sampleStat, plus the script path. Skips on windows.
+func fakeCollector(t *testing.T) *AccelCollector {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake not supported on windows")
+	}
+	path := filepath.Join(t.TempDir(), "accel-cmd")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\ncat <<'EOF'\n"+sampleStat+"EOF\n"), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	return NewAccelCollector(path, time.Second)
+}
+
 func TestNewAccelCollector(t *testing.T) {
-	if c := NewAccelCollector("accel-cmd"); c == nil {
+	if c := NewAccelCollector("accel-cmd", time.Second); c == nil {
 		t.Fatal("NewAccelCollector returned nil")
+	}
+}
+
+// TestNewAccelCollectorDefaultsTimeout guards the non-positive-timeout fallback.
+func TestNewAccelCollectorDefaultsTimeout(t *testing.T) {
+	if c := NewAccelCollector("accel-cmd", 0); c.timeout != DefaultScrapeTimeout {
+		t.Errorf("timeout = %v, want %v", c.timeout, DefaultScrapeTimeout)
 	}
 }
 
 // TestDescribeEmitsDescriptors guards that Describe reports the collector's
 // fixed metrics, so prometheus.MustRegister sees a non-empty, conflict-free set.
 func TestDescribeEmitsDescriptors(t *testing.T) {
-	c := NewAccelCollector("accel-cmd")
+	c := NewAccelCollector("accel-cmd", time.Second)
 	ch := make(chan *prometheus.Desc, 256)
 	c.Describe(ch)
 	close(ch)
@@ -56,7 +94,7 @@ func gather(t *testing.T, reg *prometheus.Registry) map[string]float64 {
 // live accel-ppp, and the one that matters most for alerting.
 func TestCollectScrapeFailure(t *testing.T) {
 	reg := prometheus.NewPedanticRegistry()
-	reg.MustRegister(NewAccelCollector("/nonexistent/accel-cmd-xyz"))
+	reg.MustRegister(NewAccelCollector("/nonexistent/accel-cmd-xyz", time.Second))
 
 	vals := gather(t, reg)
 	if up, ok := vals["accel_up"]; !ok || up != 0 {
@@ -65,4 +103,59 @@ func TestCollectScrapeFailure(t *testing.T) {
 	if f, ok := vals["accel_scrape_failures_total"]; !ok || f < 1 {
 		t.Errorf("accel_scrape_failures_total = %v (present=%v), want >= 1", f, ok)
 	}
+}
+
+// TestCollectSuccess drives the happy path against a fake accel-cmd: accel_up=1,
+// counters carry Counter type (not Gauge), and labelled RADIUS series appear.
+func TestCollectSuccess(t *testing.T) {
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(fakeCollector(t))
+
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+
+	byName := make(map[string]*dto.MetricFamily, len(mfs))
+	for _, mf := range mfs {
+		byName[mf.GetName()] = mf
+	}
+
+	if up := byName["accel_up"]; up == nil || up.GetMetric()[0].GetGauge().GetValue() != 1 {
+		t.Errorf("accel_up missing or != 1: %v", up)
+	}
+	// recv_padi_total must be a Counter now, not a Gauge.
+	if padi := byName["accel_pppoe_recv_padi_total"]; padi == nil || padi.GetType() != dto.MetricType_COUNTER {
+		t.Errorf("accel_pppoe_recv_padi_total type = %v, want COUNTER", padi.GetType())
+	}
+	// labelled RADIUS series present with correct labels.
+	state := byName["accel_radius_state"]
+	if state == nil || len(state.GetMetric()) != 1 {
+		t.Fatalf("accel_radius_state missing: %v", state)
+	}
+	labels := map[string]string{}
+	for _, l := range state.GetMetric()[0].GetLabel() {
+		labels[l.GetName()] = l.GetValue()
+	}
+	if labels["server_id"] != "1" || labels["server_ip"] != "10.0.0.1" {
+		t.Errorf("radius labels = %v, want server_id=1 server_ip=10.0.0.1", labels)
+	}
+}
+
+// TestCollectConcurrent runs many overlapping scrapes; with the stateless
+// const-metric design this must be race-free (run with -race) and never panic.
+func TestCollectConcurrent(t *testing.T) {
+	c := fakeCollector(t)
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(c)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			if _, err := reg.Gather(); err != nil {
+				t.Errorf("Gather: %v", err)
+			}
+		})
+	}
+	wg.Wait()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 )
 
 // Config holds the exporter configuration
@@ -14,6 +15,7 @@ type Config struct {
 	MetricsPath   string
 	AccelCmdPath  string
 	LogLevel      string
+	ScrapeTimeout time.Duration
 }
 
 // NewConfig creates a new configuration from command line flags
@@ -24,6 +26,7 @@ func NewConfig() *Config {
 	flag.StringVar(&cfg.MetricsPath, "web.metrics-path", "/metrics", "Path under which to expose metrics")
 	flag.StringVar(&cfg.AccelCmdPath, "accel-cmd.path", "accel-cmd", "Path to accel-cmd binary")
 	flag.StringVar(&cfg.LogLevel, "log.level", "info", "Log level (debug, info, warn, error)")
+	flag.DurationVar(&cfg.ScrapeTimeout, "accel-cmd.timeout", 5*time.Second, "Maximum time to wait for accel-cmd to return")
 
 	flag.Parse()
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -5,10 +5,13 @@ package parser
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"log"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Stats represents all statistics gathered from accel-cmd
@@ -87,13 +90,21 @@ type RadiusStats struct {
 	InterimAvgTime1m float64
 }
 
-// CollectStats executes accel-cmd and parses its output
-func CollectStats(accelCmdPath string) (*Stats, error) {
-	cmd := exec.Command(accelCmdPath, "show", "stat")
+// CollectStats executes accel-cmd and parses its output. The command is bounded
+// by timeout so a hung accel-cmd cannot wedge the scrape or leak processes; a
+// non-positive timeout disables the deadline.
+func CollectStats(accelCmdPath string, timeout time.Duration) (*Stats, error) {
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, accelCmdPath, "show", "stat")
 	var out bytes.Buffer
 	cmd.Stdout = &out
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
 
@@ -163,6 +174,38 @@ func parseStats(output string) (*Stats, error) {
 	return stats, scanner.Err()
 }
 
+// atof parses a numeric field. An empty value yields 0 silently (accel-cmd
+// legitimately omits fields); a non-empty value that fails to parse yields 0
+// but is logged, so malformed output is visible to operators instead of
+// masquerading as a real zero.
+func atof(value string) float64 {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		log.Printf("parser: cannot parse %q as number: %v", value, err)
+		return 0
+	}
+	return f
+}
+
+// fields splits a "/"-delimited value (e.g. "10 / 1 / 0") into want floats.
+// It returns ok=false when the field count differs, so callers leave the
+// destination untouched rather than recording partial data.
+func fields(value string, want int) ([]float64, bool) {
+	parts := strings.Split(value, "/")
+	if len(parts) != want {
+		return nil, false
+	}
+	out := make([]float64, want)
+	for i, p := range parts {
+		out[i] = atof(p)
+	}
+	return out, true
+}
+
 // Helper functions to parse each section...
 func parseMainSection(stats *Stats, key, value string) {
 	switch key {
@@ -192,82 +235,60 @@ func parseUptime(value string) float64 {
 		return 0
 	}
 
-	hours, _ := strconv.ParseFloat(timeParts[0], 64)
-	minutes, _ := strconv.ParseFloat(timeParts[1], 64)
-	seconds, _ := strconv.ParseFloat(timeParts[2], 64)
+	hours := atof(timeParts[0])
+	minutes := atof(timeParts[1])
+	seconds := atof(timeParts[2])
 
 	return days*86400 + hours*3600 + minutes*60 + seconds
 }
 
 func parsePercentage(value string) float64 {
 	// Example: "1.23%"
-	trimmed := strings.TrimSuffix(value, "%")
-	f, _ := strconv.ParseFloat(trimmed, 64)
-	return f
+	return atof(strings.TrimSuffix(value, "%"))
 }
 
 func parseMemory(stats *Stats, value string) {
 	// Example: "12345 / 67890 K"
-	parts := strings.Split(strings.TrimSuffix(value, " K"), "/")
-	if len(parts) == 2 {
-		rss, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-		virt, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-		stats.MemRSS = rss
-		stats.MemVirt = virt
+	if v, ok := fields(strings.TrimSuffix(value, " K"), 2); ok {
+		stats.MemRSS = v[0]
+		stats.MemVirt = v[1]
 	}
 }
 
 func parseCoreSection(core *CoreStats, key, value string) {
-	// Implement parsing logic based on key
 	switch key {
 	case "mempool(allocated/available)":
 		// Example: "1024 / 2048"
-		parts := strings.Split(value, "/")
-		if len(parts) == 2 {
-			alloc, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			avail, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			core.MempoolAllocated = alloc
-			core.MempoolAvailable = avail
+		if v, ok := fields(value, 2); ok {
+			core.MempoolAllocated = v[0]
+			core.MempoolAvailable = v[1]
 		}
 	case "threads(count/active)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 2 {
-			count, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			active, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			core.ThreadCount = count
-			core.ThreadActive = active
+		if v, ok := fields(value, 2); ok {
+			core.ThreadCount = v[0]
+			core.ThreadActive = v[1]
 		}
 	case "context(count/sleep/pending)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 3 {
-			count, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			sleep, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			pending, _ := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
-			core.ContextCount = count
-			core.ContextSleeping = sleep
-			core.ContextPending = pending
+		if v, ok := fields(value, 3); ok {
+			core.ContextCount = v[0]
+			core.ContextSleeping = v[1]
+			core.ContextPending = v[2]
 		}
 	case "md_handler(count/pending)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 2 {
-			count, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			pending, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			core.MDHandlerCount = count
-			core.MDHandlerPending = pending
+		if v, ok := fields(value, 2); ok {
+			core.MDHandlerCount = v[0]
+			core.MDHandlerPending = v[1]
 		}
 	case "timer(count/pending)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 2 {
-			count, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			pending, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			core.TimerCount = count
-			core.TimerPending = pending
+		if v, ok := fields(value, 2); ok {
+			core.TimerCount = v[0]
+			core.TimerPending = v[1]
 		}
 	}
 }
 
 func parseSessionsSection(sessions *SessionStats, key, value string) {
-	f, _ := strconv.ParseFloat(value, 64)
+	f := atof(value)
 	switch key {
 	case "starting":
 		sessions.Starting = f
@@ -279,7 +300,7 @@ func parseSessionsSection(sessions *SessionStats, key, value string) {
 }
 
 func parsePPPoESection(pppoe *PPPoEStats, key, value string) {
-	f, _ := strconv.ParseFloat(value, 64)
+	f := atof(value)
 	switch key {
 	case "starting":
 		pppoe.Starting = f
@@ -305,75 +326,53 @@ func parsePPPoESection(pppoe *PPPoEStats, key, value string) {
 }
 
 func parseRadiusSection(radius *RadiusStats, key, value string) {
-	f, _ := strconv.ParseFloat(value, 64)
 	switch key {
 	case "state":
 		radius.State = value // State is a string
 	case "fail count":
-		radius.FailCount = f
+		radius.FailCount = atof(value)
 	case "request count":
-		radius.RequestCount = f
+		radius.RequestCount = atof(value)
 	case "queue length":
-		radius.QueueLength = f
+		radius.QueueLength = atof(value)
 	case "auth sent":
-		radius.AuthSent = f
+		radius.AuthSent = atof(value)
 	case "auth lost(total/5m/1m)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 3 {
-			total, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			m5, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			m1, _ := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
-			radius.AuthLostTotal = total
-			radius.AuthLost5m = m5
-			radius.AuthLost1m = m1
+		if v, ok := fields(value, 3); ok {
+			radius.AuthLostTotal = v[0]
+			radius.AuthLost5m = v[1]
+			radius.AuthLost1m = v[2]
 		}
 	case "auth avg time(5m/1m)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 2 {
-			m5, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			m1, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			radius.AuthAvgTime5m = m5
-			radius.AuthAvgTime1m = m1
+		if v, ok := fields(value, 2); ok {
+			radius.AuthAvgTime5m = v[0]
+			radius.AuthAvgTime1m = v[1]
 		}
 	case "acct sent":
-		radius.AcctSent = f
+		radius.AcctSent = atof(value)
 	case "acct lost(total/5m/1m)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 3 {
-			total, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			m5, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			m1, _ := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
-			radius.AcctLostTotal = total
-			radius.AcctLost5m = m5
-			radius.AcctLost1m = m1
+		if v, ok := fields(value, 3); ok {
+			radius.AcctLostTotal = v[0]
+			radius.AcctLost5m = v[1]
+			radius.AcctLost1m = v[2]
 		}
 	case "acct avg time(5m/1m)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 2 {
-			m5, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			m1, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			radius.AcctAvgTime5m = m5
-			radius.AcctAvgTime1m = m1
+		if v, ok := fields(value, 2); ok {
+			radius.AcctAvgTime5m = v[0]
+			radius.AcctAvgTime1m = v[1]
 		}
 	case "interim sent":
-		radius.InterimSent = f
+		radius.InterimSent = atof(value)
 	case "interim lost(total/5m/1m)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 3 {
-			total, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			m5, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			m1, _ := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
-			radius.InterimLostTotal = total
-			radius.InterimLost5m = m5
-			radius.InterimLost1m = m1
+		if v, ok := fields(value, 3); ok {
+			radius.InterimLostTotal = v[0]
+			radius.InterimLost5m = v[1]
+			radius.InterimLost1m = v[2]
 		}
 	case "interim avg time(5m/1m)":
-		parts := strings.Split(value, "/")
-		if len(parts) == 2 {
-			m5, _ := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
-			m1, _ := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
-			radius.InterimAvgTime5m = m5
-			radius.InterimAvgTime1m = m1
+		if v, ok := fields(value, 2); ok {
+			radius.InterimAvgTime5m = v[0]
+			radius.InterimAvgTime1m = v[1]
 		}
 	}
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -102,6 +102,11 @@ func CollectStats(accelCmdPath string, timeout time.Duration) (*Stats, error) {
 	}
 
 	cmd := exec.CommandContext(ctx, accelCmdPath, "show", "stat")
+	// WaitDelay bounds how long Run blocks after the context is cancelled and the
+	// process killed. Without it, a child that forks (e.g. a shell wrapper that
+	// spawns a long-running grandchild) can inherit the stdout pipe and keep it
+	// open, leaving Run stuck reading until that grandchild exits.
+	cmd.WaitDelay = 2 * time.Second
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -198,10 +198,16 @@ func atof(value string) float64 {
 
 // fields splits a "/"-delimited value (e.g. "10 / 1 / 0") into want floats.
 // It returns ok=false when the field count differs, so callers leave the
-// destination untouched rather than recording partial data.
+// destination untouched rather than recording partial data. An empty value is
+// a silent miss (accel-cmd may omit a field); a non-empty value with the wrong
+// count is logged so malformed output is visible to operators.
 func fields(value string, want int) ([]float64, bool) {
+	if strings.TrimSpace(value) == "" {
+		return nil, false
+	}
 	parts := strings.Split(value, "/")
 	if len(parts) != want {
+		log.Printf("parser: expected %d fields in %q, got %d", want, value, len(parts))
 		return nil, false
 	}
 	out := make([]float64, want)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -2,8 +2,58 @@ package parser
 
 import (
 	"math"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 )
+
+// fakeAccelCmd writes an executable shell script to a temp dir that runs body,
+// and returns its path. Skips on non-POSIX platforms.
+func fakeAccelCmd(t *testing.T, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake not supported on windows")
+	}
+	path := filepath.Join(t.TempDir(), "accel-cmd")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake: %v", err)
+	}
+	return path
+}
+
+func TestCollectStatsSuccess(t *testing.T) {
+	path := fakeAccelCmd(t, "cat <<'EOF'\n"+sampleStat+"EOF")
+	st, err := CollectStats(path, time.Second)
+	if err != nil {
+		t.Fatalf("CollectStats: %v", err)
+	}
+	wantEq(t, "CPUPercent", st.CPUPercent, 1.50)
+	wantEq(t, "Sessions.Active", st.Sessions.Active, 100)
+	if len(st.RadiusServers) != 1 {
+		t.Fatalf("RadiusServers = %d, want 1", len(st.RadiusServers))
+	}
+}
+
+// TestCollectStatsTimeout proves a hung accel-cmd is killed at the deadline
+// instead of wedging the scrape forever.
+func TestCollectStatsTimeout(t *testing.T) {
+	path := fakeAccelCmd(t, "sleep 5")
+	start := time.Now()
+	if _, err := CollectStats(path, 50*time.Millisecond); err == nil {
+		t.Fatal("CollectStats: want timeout error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("CollectStats blocked %v, timeout not enforced", elapsed)
+	}
+}
+
+func TestCollectStatsExecError(t *testing.T) {
+	if _, err := CollectStats("/nonexistent/accel-cmd-xyz", time.Second); err == nil {
+		t.Fatal("CollectStats: want exec error, got nil")
+	}
+}
 
 // sampleStat is a representative `accel-cmd show stat` capture exercising every
 // section the parser understands: the unlabelled main block, core, sessions,
@@ -162,6 +212,26 @@ func TestParseStatsEmpty(t *testing.T) {
 	if len(st.RadiusServers) != 0 {
 		t.Errorf("RadiusServers = %d, want 0", len(st.RadiusServers))
 	}
+}
+
+// TestParseStatsMalformed verifies malformed numeric fields degrade to 0
+// without aborting the parse or corrupting sibling fields. A bad sub-field in a
+// "/"-delimited value becomes 0 while its valid neighbours still parse.
+func TestParseStatsMalformed(t *testing.T) {
+	in := `radius(1, 10.0.0.1):
+  state: active
+  auth sent: notanumber
+  auth lost(total/5m/1m): bad / 1 / 0
+`
+	st, err := parseStats(in)
+	if err != nil {
+		t.Fatalf("parseStats: %v", err)
+	}
+	rs := st.RadiusServers["1"]
+	wantEq(t, "AuthSent", rs.AuthSent, 0)           // unparseable scalar -> 0
+	wantEq(t, "AuthLostTotal", rs.AuthLostTotal, 0) // bad sub-field -> 0
+	wantEq(t, "AuthLost5m", rs.AuthLost5m, 1)       // neighbours still parse
+	wantEq(t, "AuthLost1m", rs.AuthLost1m, 0)
 }
 
 func TestParseUptime(t *testing.T) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -39,12 +39,16 @@ func TestCollectStatsSuccess(t *testing.T) {
 // TestCollectStatsTimeout proves a hung accel-cmd is killed at the deadline
 // instead of wedging the scrape forever.
 func TestCollectStatsTimeout(t *testing.T) {
-	path := fakeAccelCmd(t, "sleep 5")
+	// Background the sleep so it inherits stdout and outlives the killed shell,
+	// deterministically reproducing the pipe-drain hang on every platform.
+	path := fakeAccelCmd(t, "sleep 10 & wait")
 	start := time.Now()
 	if _, err := CollectStats(path, 50*time.Millisecond); err == nil {
 		t.Fatal("CollectStats: want timeout error, got nil")
 	}
-	if elapsed := time.Since(start); elapsed > 2*time.Second {
+	// Deadline is 50ms; WaitDelay caps post-kill pipe drain at 2s. A grandchild
+	// holding the pipe must not block Run for the full sleep.
+	if elapsed := time.Since(start); elapsed > 4*time.Second {
 		t.Errorf("CollectStats blocked %v, timeout not enforced", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

This pull request reworks how the exporter collects and exposes metrics so that it behaves correctly and reliably under real production load.

The core change addresses a concurrency problem. The collector previously kept a large set of long-lived metric objects and mutated them in place every time it was scraped. Because Prometheus can scrape the same target from more than one place at once — most commonly a high-availability Prometheus pair — those overlapping scrapes shared and overwrote the same state, which could produce corrupted or misleading metrics. The collector has been rewritten to follow the idiomatic Prometheus pattern of building fresh, immutable metrics on each scrape, which removes the shared state entirely and makes concurrent scrapes safe. The same rewrite also corrects the type of the cumulative counters and ensures that metrics for servers that have disappeared are no longer reported as stale.

Alongside that, the pull request hardens the exporter against a few ways it could misbehave operationally. The external command it runs to gather statistics is now bounded by a configurable timeout, so a hung command can no longer block scrapes or leak processes. Malformed input from that command is now logged rather than silently reported as a legitimate zero, giving operators visibility into bad data. Finally, the HTTP server is configured with sensible read, write, and idle timeouts to protect it against slow or stalled clients.

## Compatibility notes

The cumulative `*_total` metrics now report as Prometheus counters rather than gauges; their names are unchanged and queries using `rate()` continue to work, now more correctly. A new `-accel-cmd.timeout` flag is added (default 5s).
