### PR TITLE
fix: expose delayed PADO as a counter, align dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The exporter exposes the following metrics:
 
 - `accel_pppoe_starting`: Number of PPPoE sessions starting
 - `accel_pppoe_active`: Number of active PPPoE sessions
-- `accel_pppoe_delayed_pado`: Number of delayed PADO packets
+- `accel_pppoe_delayed_pado_total`: Total delayed PADO packets
 - `accel_pppoe_recv_padi_total`: Total received PADI packets
 - `accel_pppoe_drop_padi_total`: Total dropped PADI packets
 - `accel_pppoe_sent_pado_total`: Total sent PADO packets

--- a/dashboards/accel-ppp-overview.json
+++ b/dashboards/accel-ppp-overview.json
@@ -298,7 +298,7 @@
         "id": 8,
         "targets": [
           {
-            "expr": "rate(accel_pppoe_delayed_pado[1m])",
+            "expr": "rate(accel_pppoe_delayed_pado_total[1m])",
             "legendFormat": "Delayed PADO Rate",
             "refId": "A"
           },

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -48,7 +48,7 @@ var (
 
 	pppoeStartingDesc    = newDesc("accel_pppoe_starting", "Number of PPPoE sessions starting.")
 	pppoeActiveDesc      = newDesc("accel_pppoe_active", "Number of active PPPoE sessions.")
-	pppoeDelayedPADODesc = newDesc("accel_pppoe_delayed_pado", "Number of delayed PADO packets.")
+	pppoeDelayedPADODesc = newDesc("accel_pppoe_delayed_pado_total", "Total delayed PADO packets.")
 	pppoeRecvPADIDesc    = newDesc("accel_pppoe_recv_padi_total", "Total received PADI packets.")
 	pppoeDropPADIDesc    = newDesc("accel_pppoe_drop_padi_total", "Total dropped PADI packets.")
 	pppoeSentPADODesc    = newDesc("accel_pppoe_sent_pado_total", "Total sent PADO packets.")
@@ -186,7 +186,7 @@ func (c *AccelCollector) Collect(ch chan<- prometheus.Metric) {
 	// PPPoE
 	gauge(pppoeStartingDesc, stats.PPPoE.Starting)
 	gauge(pppoeActiveDesc, stats.PPPoE.Active)
-	gauge(pppoeDelayedPADODesc, stats.PPPoE.DelayedPADO)
+	counter(pppoeDelayedPADODesc, stats.PPPoE.DelayedPADO)
 	counter(pppoeRecvPADIDesc, stats.PPPoE.RecvPADI)
 	counter(pppoeDropPADIDesc, stats.PPPoE.DropPADI)
 	counter(pppoeSentPADODesc, stats.PPPoE.SentPADO)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -47,8 +47,10 @@ func TestCollectStatsTimeout(t *testing.T) {
 		t.Fatal("CollectStats: want timeout error, got nil")
 	}
 	// Deadline is 50ms; WaitDelay caps post-kill pipe drain at 2s. A grandchild
-	// holding the pipe must not block Run for the full sleep.
-	if elapsed := time.Since(start); elapsed > 4*time.Second {
+	// holding the pipe must not block Run for the full 10s sleep. The bound is
+	// generous to stay non-flaky under -race/CI contention while still proving
+	// the deadline is enforced.
+	if elapsed := time.Since(start); elapsed > 6*time.Second {
 		t.Errorf("CollectStats blocked %v, timeout not enforced", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #20. While reviewing the Grafana dashboard against the now-counter `*_total` metrics, one PPPoE metric was found to be mistyped.

`accel_pppoe_delayed_pado` is a cumulative value, just like its sibling PADx metrics (`recv_padi`, `drop_padi`, `sent_pado`, …), and the dashboard already graphs it with `rate()`. It was, however, the only one still emitted as a gauge. This pull request renames it to `accel_pppoe_delayed_pado_total` and emits it as a counter so `rate()`/`increase()` are reset-aware, and updates the dashboard query and README to match.

It also widens the bound in the `CollectStats` timeout test so it stays non-flaky under `-race`/CI contention while still proving the deadline is enforced.

## Compatibility note

The metric `accel_pppoe_delayed_pado` is renamed to `accel_pppoe_delayed_pado_total` and its type changes from gauge to counter. Any external query referencing the old name must be updated; the bundled dashboard already is.